### PR TITLE
added support for allowed_jobs on entity

### DIFF
--- a/client/Models/Abstracts/SDAbstractSpecification.j
+++ b/client/Models/Abstracts/SDAbstractSpecification.j
@@ -48,6 +48,7 @@
     CPString            _objectRESTName         @accessors(property=objectRESTName)
     CPString            _package                @accessors(property=package);
     CPString            _userlabel              @accessors(property=userlabel);
+    CPArrayController   _allowedJobs            @accessors(property=allowedJobs);
 
     SDAttributesFetcher _attributes             @accessors(property=attributes);
     SDChildAPIsFetcher  _childAPIs              @accessors(property=childAPIs);
@@ -57,6 +58,7 @@
 {
     if (self = [super init])
     {
+        [self exposeLocalKeyPathToREST:@"allowedJobs"];
         [self exposeLocalKeyPathToREST:@"allowsCreate"];
         [self exposeLocalKeyPathToREST:@"allowsDelete"];
         [self exposeLocalKeyPathToREST:@"allowsGet"];
@@ -72,6 +74,7 @@
         [self exposeLocalKeyPathToREST:@"template"];
         [self exposeLocalKeyPathToREST:@"userlabel"];
 
+        _allowedJobs  = [[CPArrayController alloc] initWithContent:[]];
         _allowsDelete = YES;
         _allowsGet    = YES;
         _allowsUpdate = YES;

--- a/client/Resources/Model.xib
+++ b/client/Resources/Model.xib
@@ -10,10 +10,12 @@
                 <outlet property="abstractsController" destination="qbA-Uh-tgT" id="4Hz-pT-eU3"/>
                 <outlet property="buttonSave" destination="j9h-om-vAO" id="JsS-U6-IlH"/>
                 <outlet property="editionViewDocumentation" destination="ePO-8D-WzU" id="HoO-hX-1x3"/>
+                <outlet property="editionViewJobs" destination="0no-I5-BWF" id="HGC-ac-BqQ"/>
                 <outlet property="editionViewOperations" destination="Wbv-wx-pBt" id="3F3-7H-0nS"/>
                 <outlet property="editionViewREST" destination="tKt-qr-NJk" id="fDS-Vx-ygr"/>
                 <outlet property="scrollViewMain" destination="nFv-3U-Y02" id="teH-WK-bxD"/>
                 <outlet property="splitViewEditor" destination="CF7-94-sye" id="QVb-ns-Qzm"/>
+                <outlet property="tableViewJobValues" destination="MTc-dm-FBh" id="Huj-rh-Eh3"/>
                 <outlet property="view" destination="1" id="g9j-fa-jAg"/>
                 <outlet property="viewAbstractsContainer" destination="Jdr-8q-qLb" id="49g-oS-ECi"/>
                 <outlet property="viewBottom" destination="5DG-0e-hCH" id="kjg-bW-rfk"/>
@@ -102,7 +104,7 @@
                     </holdingPriorities>
                 </splitView>
             </subviews>
-            <point key="canvasLocation" x="529" y="690"/>
+            <point key="canvasLocation" x="616" y="1236"/>
         </customView>
         <customView misplaced="YES" id="ePO-8D-WzU">
             <rect key="frame" x="0.0" y="0.0" width="405" height="274"/>
@@ -430,5 +432,89 @@
             </subviews>
             <point key="canvasLocation" x="494.5" y="413"/>
         </customView>
+        <customView misplaced="YES" id="0no-I5-BWF">
+            <rect key="frame" x="0.0" y="0.0" width="405" height="113"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+            <subviews>
+                <button id="U70-Ul-hXz">
+                    <rect key="frame" x="21" y="5" width="8" height="8"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="icon-repository" imagePosition="only" alignment="center" controlSize="mini" imageScaling="proportionallyDown" inset="2" id="5nI-4g-vMP">
+                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="miniSystem"/>
+                    </buttonCell>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="tag" value="allowedJobs_add:"/>
+                    </userDefinedRuntimeAttributes>
+                </button>
+                <button id="aaq-LE-T1d">
+                    <rect key="frame" x="35" y="5" width="8" height="8"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="icon-repository" imagePosition="only" alignment="center" controlSize="mini" imageScaling="proportionallyDown" inset="2" id="CFo-kM-4UE">
+                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="miniSystem"/>
+                    </buttonCell>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="tag" value="allowedJobs_remove:"/>
+                    </userDefinedRuntimeAttributes>
+                </button>
+                <scrollView borderType="line" autohidesScrollers="YES" horizontalLineScroll="17" horizontalPageScroll="10" verticalLineScroll="17" verticalPageScroll="10" usesPredominantAxisScrolling="NO" id="B27-zW-715">
+                    <rect key="frame" x="20" y="15" width="365" height="68"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                    <clipView key="contentView" id="Msn-YE-JKe">
+                        <rect key="frame" x="1" y="1" width="363" height="66"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" id="MTc-dm-FBh">
+                                <rect key="frame" x="0.0" y="0.0" width="363" height="66"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <size key="intercellSpacing" width="3" height="3"/>
+                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                                <tableColumns>
+                                    <tableColumn identifier="" width="360" minWidth="40" maxWidth="1000" id="FzQ-04-vUN">
+                                        <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
+                                            <font key="font" metaFont="smallSystem"/>
+                                            <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                        </tableHeaderCell>
+                                        <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" title="Text Cell" id="BbC-tM-qoX">
+                                            <font key="font" metaFont="smallSystem"/>
+                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                    </tableColumn>
+                                </tableColumns>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="tag" value="allowedJobs"/>
+                                </userDefinedRuntimeAttributes>
+                            </tableView>
+                        </subviews>
+                    </clipView>
+                    <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="YZd-QB-Fd8">
+                        <rect key="frame" x="1" y="51" width="363" height="16"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </scroller>
+                    <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="ICb-Fr-V5j">
+                        <rect key="frame" x="224" y="17" width="15" height="102"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </scroller>
+                </scrollView>
+                <textField verticalHuggingPriority="750" misplaced="YES" id="T48-nx-c0f">
+                    <rect key="frame" x="18" y="91" width="369" height="17"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Allowed Jobs" id="Ix7-kr-AcS">
+                        <font key="font" metaFont="systemBold"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+            </subviews>
+            <point key="canvasLocation" x="494.5" y="653.5"/>
+        </customView>
     </objects>
+    <resources>
+        <image name="icon-repository" width="64" height="64"/>
+    </resources>
 </document>

--- a/client/ViewControllers/SDModelViewController.j
+++ b/client/ViewControllers/SDModelViewController.j
@@ -37,10 +37,13 @@
 @implementation SDModelViewController : NUModuleSelfParent
 {
     @outlet CPView                          editionViewDocumentation;
+    @outlet CPView                          editionViewJobs;
     @outlet CPView                          editionViewREST;
     @outlet CPView                          editionViewOperations;
     @outlet CPView                          viewAbstractsContainer;
     @outlet CPView                          viewContainer;
+    @outlet CPTableView                     tableViewJobValues;
+
 
     @outlet SDModelAbstractsViewController  abstractsController;
 }
@@ -60,7 +63,7 @@
 }
 
 - (void)viewDidLoad
-{
+{    
     [super viewDidLoad];
 
     [[self view] setBackgroundColor:NUSkinColorGrey];
@@ -84,6 +87,11 @@
     [viewAbstractsContainer setFrame:[view bounds]];
     [viewAbstractsContainer addSubview:[abstractsController view]];
     [abstractsController setParentModule:self];
+    
+    var textField = [[tableViewJobValues tableColumns][0] dataView];
+    [textField setPlaceholderString:@"Double click to enter a value"];
+    [[tableViewJobValues tableColumns][0] setDataView:nil];
+    [[tableViewJobValues tableColumns][0] setDataView:textField];
 }
 
 
@@ -121,7 +129,8 @@
     var contextSpecification = [[NUModuleContext alloc] initWithName:@"Model" identifier:[SDSpecification RESTName]];
     [contextSpecification setButtonSave:buttonSave];
     [contextSpecification setEditionView:[self view]];
-    [contextSpecification setAdditionalEditionViews:[editionViewREST, editionViewDocumentation, editionViewOperations]];
+    [contextSpecification setSearchForTagsRecursively:YES];
+    [contextSpecification setAdditionalEditionViews:[editionViewREST, editionViewDocumentation, editionViewOperations, editionViewJobs]];
     [self registerContext:contextSpecification forClass:SDSpecification];
 
     var contextAbstract = [[NUModuleContext alloc] initWithName:@"Model" identifier:[SDAbstract RESTName]];
@@ -138,7 +147,7 @@
         if ([_currentParent root])
             return [editionViewREST, editionViewDocumentation];
         else
-            return [editionViewREST, editionViewOperations, editionViewDocumentation];
+            return [editionViewREST, editionViewOperations, editionViewJobs, editionViewDocumentation];
     }
     else
         return [editionViewOperations, editionViewDocumentation];

--- a/server/specs/specification.spec
+++ b/server/specs/specification.spec
@@ -29,6 +29,11 @@
             "description": "true if the corresponding entity serves as a template",
             "name": "template",
             "type": "boolean"
+        },
+        {
+            "description": "Applicable jobs for this entity",
+            "name": "allowedJobs",
+            "type": "list"
         }
     ],
     "model": {

--- a/server/specsdirectorserver/lib/exporter.py
+++ b/server/specsdirectorserver/lib/exporter.py
@@ -67,6 +67,7 @@ class SDSpecificationExporter():
             mono_spec.resource_name = specification.object_resource_name
             mono_spec.userlabel = specification.userlabel
             mono_spec.template = specification.template
+            mono_spec.allowed_jobs = sorted(specification.allowed_jobs) if specification.allowed_jobs else None
 
         mono_spec.child_apis = self._export_child_apis(specification=specification, session_username=session_username)
         mono_spec.attributes = self._export_attributes(specification=specification, session_username=session_username)

--- a/server/specsdirectorserver/lib/importer.py
+++ b/server/specsdirectorserver/lib/importer.py
@@ -168,6 +168,7 @@ class SDSpecificationImporter():
                 specification.root = mono_specification.is_root
                 specification.userlabel = mono_specification.userlabel
                 specification.template = mono_specification.template
+                specification.allowed_jobs = sorted(mono_specification.allowed_jobs) if mono_specification.allowed_jobs else None
 
             self._storage_controller.create(user_identifier=session_username, resource=specification, parent=repository)
 


### PR DESCRIPTION
UI sample:
<img width="1112" alt="screen shot 2018-03-16 at 7 13 47 pm" src="https://user-images.githubusercontent.com/24920919/37550669-821c3ed0-294e-11e8-8e66-8df1f1e37edb.png">


Sample generated spec:
```{
    "attributes": [],
    "children": [],
    "model": {
        "allowed_jobs": [
            "BAD_JOB",
            "GOOD_JOB",
            "JOBLESS",
            "OK_JOB"
        ],
        "create": null,
        "delete": true,
        "description": "test 123",
        "entity_name": "DummyEntity",
        "extends": [],
        "get": true,
        "package": null,
        "resource_name": "dummyentities",
        "rest_name": "dummyentity",
        "root": null,
        "template": null,
        "update": true,
        "userlabel": "Dummy One"
    }
}
```